### PR TITLE
tcの挿入先を#content直下に変更

### DIFF
--- a/css/tc.css
+++ b/css/tc.css
@@ -1,10 +1,34 @@
 @charset "UTF-8";
 
+#content {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: start !important;
+  -ms-flex-pack: start !important;
+  justify-content: start !important;
+	-webkit-box-align: center;
+	-ms-flex-align: center;
+  align-items: center;
+}
+
+#editor {
+  padding-top: 0px !important;
+}
+
 #tc-wrapper {
   vertical-align: top;
   font-size: .75rem;
-  padding: 0px;
-  margin-bottom: 40px;
+  padding-left: 55px;
+  padding-right: 55px;
+  padding-top: 80px;
+  padding-bottom: 40px;
+  width: 100%;
+  max-width: 1000px;
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   grid-gap: 0

--- a/js/tc.js
+++ b/js/tc.js
@@ -15,7 +15,7 @@ $(function () {
   var defaultTaskBar = "true"; // タスクバー使用の初期値
 
   var tchtml;
-  var tcParentId = "#editor"; // tcの親要素のID
+  var tcParentId = "#content"; // tcの親要素のID
   var taskListParentId = "#editor"; // タスクリストを内包する要素のID
 
   var tcCurrentDate = new Date();

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extName__",
   "description": "__MSG_extDescription__",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "default_locale": "en",
   "browser_action": {
     "default_icon": "img/icon.png"


### PR DESCRIPTION
- ページ遷移時にtcが再描画されないように